### PR TITLE
chore: rebuild with and require protobuf 5.28.3 to silence grpc minor…

### DIFF
--- a/.github/workflows/extensive_vector_search_tests.yml
+++ b/.github/workflows/extensive_vector_search_tests.yml
@@ -3,7 +3,7 @@ name: Run long running vector search tests
 on:
   push:
     branches:
-      - main
+      - dev
 
 jobs:
   test-exhaustive-vector-search:

--- a/.github/workflows/extensive_vector_search_tests.yml
+++ b/.github/workflows/extensive_vector_search_tests.yml
@@ -3,7 +3,7 @@ name: Run long running vector search tests
 on:
   push:
     branches:
-      - dev
+      - main
 
 jobs:
   test-exhaustive-vector-search:

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -673,7 +673,7 @@ jobs:
     - name: Build and install aerospike-vector-search
       run: |
         python -m build
-        pip install dist/aerospike_vector_search-3.0.0-py3-none-any.whl
+        pip install dist/aerospike_vector_search-3.0.1-py3-none-any.whl
 
     - name: Upload to Codecov
       uses: codecov/codecov-action@v4

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -3,7 +3,7 @@ name: Run Unit Tests
 on:
   pull_request:
     branches:
-      - dev
+      - main
   push:
     branches:
       - main

--- a/proto/codegen.sh
+++ b/proto/codegen.sh
@@ -3,7 +3,7 @@
 cd "$(dirname "$0")"
 
 # Generate the gRPC client code
-python3 -m pip install grpcio-tools
+python3 -m pip install grpcio-tools --upgrade
 python3 -m grpc_tools.protoc \
   --proto_path=. \
   --python_out=../src/aerospike_vector_search/shared/proto_generated/ \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ classifiers = [
 version = "3.0.0"
 requires-python = ">3.8"
 dependencies = [
-    "grpcio == 1.67.0",
-    "protobuf == 5.28.2",
+    "grpcio == 1.67.1",
+    "protobuf == 5.28.3",
     "pyjwt == 2.9.0",
     "numpy",
     "sphinx_rtd_theme"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Database"
 ]
-version = "3.0.0"
+version = "3.0.1"
 requires-python = ">3.8"
 dependencies = [
     "grpcio == 1.67.1",

--- a/src/aerospike_vector_search/shared/proto_generated/auth_pb2_grpc.py
+++ b/src/aerospike_vector_search/shared/proto_generated/auth_pb2_grpc.py
@@ -5,7 +5,7 @@ import warnings
 
 from . import auth_pb2 as auth__pb2
 
-GRPC_GENERATED_VERSION = '1.67.0'
+GRPC_GENERATED_VERSION = '1.67.1'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/src/aerospike_vector_search/shared/proto_generated/index_pb2_grpc.py
+++ b/src/aerospike_vector_search/shared/proto_generated/index_pb2_grpc.py
@@ -7,7 +7,7 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 from . import index_pb2 as index__pb2
 from . import types_pb2 as types__pb2
 
-GRPC_GENERATED_VERSION = '1.67.0'
+GRPC_GENERATED_VERSION = '1.67.1'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/src/aerospike_vector_search/shared/proto_generated/transact_pb2_grpc.py
+++ b/src/aerospike_vector_search/shared/proto_generated/transact_pb2_grpc.py
@@ -7,7 +7,7 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 from . import transact_pb2 as transact__pb2
 from . import types_pb2 as types__pb2
 
-GRPC_GENERATED_VERSION = '1.67.0'
+GRPC_GENERATED_VERSION = '1.67.1'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/src/aerospike_vector_search/shared/proto_generated/types_pb2_grpc.py
+++ b/src/aerospike_vector_search/shared/proto_generated/types_pb2_grpc.py
@@ -4,7 +4,7 @@ import grpc
 import warnings
 
 
-GRPC_GENERATED_VERSION = '1.67.0'
+GRPC_GENERATED_VERSION = '1.67.1'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/src/aerospike_vector_search/shared/proto_generated/user_admin_pb2_grpc.py
+++ b/src/aerospike_vector_search/shared/proto_generated/user_admin_pb2_grpc.py
@@ -7,7 +7,7 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 from . import types_pb2 as types__pb2
 from . import user_admin_pb2 as user__admin__pb2
 
-GRPC_GENERATED_VERSION = '1.67.0'
+GRPC_GENERATED_VERSION = '1.67.1'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/src/aerospike_vector_search/shared/proto_generated/vector_db_pb2_grpc.py
+++ b/src/aerospike_vector_search/shared/proto_generated/vector_db_pb2_grpc.py
@@ -6,7 +6,7 @@ import warnings
 from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 from . import vector_db_pb2 as vector__db__pb2
 
-GRPC_GENERATED_VERSION = '1.67.0'
+GRPC_GENERATED_VERSION = '1.67.1'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 


### PR DESCRIPTION
… version difference warnings vec-420

@rahul-aerospike Looks like those warnings we are seeing were rolled back in the next version of protobuf https://github.com/protocolbuffers/protobuf/issues/18096 . Upgrading the required protobuf version removes the warnings for me. It seems like grpcio-tools current protoc version is set to 5.27 for now so I don't think we can build with a newer protoc until they upgrade that.

Once we cut another release with these changes the warnings should disappear.