### PR TITLE
docs: format read the docs so that each function argument appears on a separate line vec-529

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,7 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "aerospike-vector-search"
-copyright = "2024, Dominic Pelini"
+copyright = "2025, Aerospike Inc."
 author = "Dominic Pelini"
 release = "0.6.1"
 
@@ -27,3 +27,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 html_theme = "sphinx_rtd_theme"
 html_static_path = ["_static"]
+
+# -- Options for autodoc -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html
+maximum_signature_line_length = 80


### PR DESCRIPTION
After change: 
<img width="730" alt="Screenshot 2025-02-18 at 12 43 12 PM" src="https://github.com/user-attachments/assets/e25d8d8b-84cb-49f3-8c3d-e3c5c59d4255" />


Before change:
<img width="766" alt="Screenshot 2025-02-18 at 12 43 50 PM" src="https://github.com/user-attachments/assets/70e98c03-1440-4497-910a-e7db075c27a6" />
