### PR TITLE
feat: index operations now wait for index changes to sync accross the cluster before returning vec-533

### DIFF
--- a/src/aerospike_vector_search/aio/client.py
+++ b/src/aerospike_vector_search/aio/client.py
@@ -18,11 +18,11 @@ from ..shared.conversions import fromIndexStatusResponse
 logger = logging.getLogger(__name__)
 
 
-async def _ensure_indexes_in_sync(func):
+def _ensure_indexes_in_sync(func):
     """Decorator to ensure indexes are in sync after an index operation."""
     @functools.wraps(func)
     async def wrapper(self, *args, **kwargs):
-        result = func(self, *args, **kwargs)  # Call the original function
+        result = await func(self, *args, **kwargs)  # Call the original function
         await self._indexes_in_sync()  # Ensure indexes are in sync
         return result
     return wrapper

--- a/src/aerospike_vector_search/aio/client.py
+++ b/src/aerospike_vector_search/aio/client.py
@@ -812,6 +812,13 @@ class Client(BaseClientMixin, AdminBaseClientMixin):
         except grpc.RpcError as e:
             logger.error("Failed to create index with error: %s", e)
             raise types.AVSServerError(rpc_error=e)
+        try:
+            await self._wait_for_index_creation(
+                namespace=namespace, name=name, timeout=100_000
+            )
+        except grpc.RpcError as e:
+            logger.error("Failed waiting for creation with error: %s", e)
+            raise types.AVSServerError(rpc_error=e)
 
     @_ensure_indexes_in_sync
     async def index_update(
@@ -909,6 +916,13 @@ class Client(BaseClientMixin, AdminBaseClientMixin):
             )
         except grpc.RpcError as e:
             logger.error("Failed to drop index with error: %s", e)
+            raise types.AVSServerError(rpc_error=e)
+        try:
+            await self._wait_for_index_deletion(
+                namespace=namespace, name=name, timeout=100_000
+            )
+        except grpc.RpcError as e:
+            logger.error("Failed waiting for deletion with error: %s", e)
             raise types.AVSServerError(rpc_error=e)
 
     async def index_list(
@@ -1396,6 +1410,90 @@ class Client(BaseClientMixin, AdminBaseClientMixin):
             logger.error("Failed to list roles with error: %s", e)
             raise types.AVSServerError(rpc_error=e)
         return self._respond_list_roles(response)
+
+    async def _wait_for_index_creation(
+        self,
+        *,
+        namespace: str,
+        name: str,
+        timeout: int = sys.maxsize,
+        wait_interval: float = 0.1,
+    ) -> None:
+        """
+        Wait for the index to be created.
+        """
+        await self._channel_provider._is_ready()
+
+        (index_stub, wait_interval, start_time, _, _, index_creation_request) = (
+            self._prepare_wait_for_index_waiting(namespace, name, wait_interval)
+        )
+        while True:
+
+            try:
+                self._check_timeout(start_time, timeout)
+            except types.AVSClientError as e:
+                logger.error("Failed waiting for index creation with error: %s", e)
+                raise
+
+            try:
+                await index_stub.GetStatus(
+                    index_creation_request,
+                    credentials=self._channel_provider.get_token(),
+                )
+                logger.debug("Index created successfully")
+                # Index has been created
+                return
+            except grpc.RpcError as e:
+                if e.code() == grpc.StatusCode.NOT_FOUND:
+
+                    # Wait for some more time.
+                    await asyncio.sleep(wait_interval)
+                else:
+                    logger.error("Failed waiting for index creation with error: %s", e)
+                    raise types.AVSServerError(rpc_error=e)
+
+    async def _wait_for_index_deletion(
+        self,
+        *,
+        namespace: str,
+        name: str,
+        timeout: int = sys.maxsize,
+        wait_interval: float = 0.1,
+    ) -> None:
+        """
+        Wait for the index to be deleted.
+        """
+        await self._channel_provider._is_ready()
+
+        # Wait interval between polling
+        (index_stub, wait_interval, start_time, _, _, index_deletion_request) = (
+            self._prepare_wait_for_index_waiting(namespace, name, wait_interval)
+        )
+
+        while True:
+
+            try:
+                self._check_timeout(start_time, timeout)
+            except types.AVSClientError as e:
+                logger.error("Failed waiting for index deletion with error: %s", e)
+                raise
+
+            try:
+                await index_stub.GetStatus(
+                    index_deletion_request,
+                    credentials=self._channel_provider.get_token(),
+                )
+                # Wait for some more time.
+                await asyncio.sleep(wait_interval)
+            except grpc.RpcError as e:
+                if e.code() == grpc.StatusCode.NOT_FOUND:
+                    logger.debug("Index deleted successfully")
+                    # Index has been created
+                    return
+                else:
+                    logger.error("Failed waiting for index deletion with error: %s", e)
+
+                    raise types.AVSServerError(rpc_error=e)
 
     async def close(self):
         """

--- a/src/aerospike_vector_search/aio/client.py
+++ b/src/aerospike_vector_search/aio/client.py
@@ -1,4 +1,3 @@
-import functools
 import asyncio
 import logging
 import sys

--- a/src/aerospike_vector_search/aio/client.py
+++ b/src/aerospike_vector_search/aio/client.py
@@ -1103,7 +1103,7 @@ class Client(BaseClientMixin, AdminBaseClientMixin):
             index_storage=index_info.storage,
         )
 
-    async def indexes_in_sync(
+    async def _indexes_in_sync(
             self,
             *,
             timeout: Optional[int] = None,
@@ -1111,8 +1111,6 @@ class Client(BaseClientMixin, AdminBaseClientMixin):
         """
         Waits for indexes to be in sync across the cluster.
         This call returns when all nodes in the AVS cluster have the same copy of the index.
-
-        You can use this call after creating, deleting, or updating an index to ensure that the changes are propagated to all nodes.
 
         :param timeout: Time in seconds this operation will wait before raising an :class:`AVSServerError <aerospike_vector_search.types.AVSServerError>`. Defaults to None.
         :type timeout: int

--- a/src/aerospike_vector_search/aio/client.py
+++ b/src/aerospike_vector_search/aio/client.py
@@ -812,13 +812,6 @@ class Client(BaseClientMixin, AdminBaseClientMixin):
         except grpc.RpcError as e:
             logger.error("Failed to create index with error: %s", e)
             raise types.AVSServerError(rpc_error=e)
-        try:
-            await self._wait_for_index_creation(
-                namespace=namespace, name=name, timeout=100_000
-            )
-        except grpc.RpcError as e:
-            logger.error("Failed waiting for creation with error: %s", e)
-            raise types.AVSServerError(rpc_error=e)
 
     @_ensure_indexes_in_sync
     async def index_update(
@@ -916,13 +909,6 @@ class Client(BaseClientMixin, AdminBaseClientMixin):
             )
         except grpc.RpcError as e:
             logger.error("Failed to drop index with error: %s", e)
-            raise types.AVSServerError(rpc_error=e)
-        try:
-            await self._wait_for_index_deletion(
-                namespace=namespace, name=name, timeout=100_000
-            )
-        except grpc.RpcError as e:
-            logger.error("Failed waiting for deletion with error: %s", e)
             raise types.AVSServerError(rpc_error=e)
 
     async def index_list(
@@ -1410,79 +1396,6 @@ class Client(BaseClientMixin, AdminBaseClientMixin):
             logger.error("Failed to list roles with error: %s", e)
             raise types.AVSServerError(rpc_error=e)
         return self._respond_list_roles(response)
-
-    async def _wait_for_index_creation(
-        self,
-        *,
-        namespace: str,
-        name: str,
-        timeout: int = sys.maxsize,
-        wait_interval: float = 0.1,
-    ) -> None:
-        """
-        Wait for the index to be created.
-        """
-        await self._channel_provider._is_ready()
-
-        (index_stub, wait_interval, start_time, _, _, index_creation_request) = (
-            self._prepare_wait_for_index_waiting(namespace, name, wait_interval)
-        )
-        while True:
-            self._check_timeout(start_time, timeout)
-            try:
-                await index_stub.GetStatus(
-                    index_creation_request,
-                    credentials=self._channel_provider.get_token(),
-                )
-                logger.debug("Index created successfully")
-                # Index has been created
-                return
-            except grpc.RpcError as e:
-                if e.code() == grpc.StatusCode.NOT_FOUND:
-
-                    # Wait for some more time.
-                    await asyncio.sleep(wait_interval)
-                else:
-                    logger.error("Failed waiting for index creation with error: %s", e)
-                    raise types.AVSServerError(rpc_error=e)
-
-    async def _wait_for_index_deletion(
-        self,
-        *,
-        namespace: str,
-        name: str,
-        timeout: int = sys.maxsize,
-        wait_interval: float = 0.1,
-    ) -> None:
-        """
-        Wait for the index to be deleted.
-        """
-        await self._channel_provider._is_ready()
-
-        # Wait interval between polling
-        (index_stub, wait_interval, start_time, _, _, index_deletion_request) = (
-            self._prepare_wait_for_index_waiting(namespace, name, wait_interval)
-        )
-
-        while True:
-            self._check_timeout(start_time, timeout)
-
-            try:
-                await index_stub.GetStatus(
-                    index_deletion_request,
-                    credentials=self._channel_provider.get_token(),
-                )
-                # Wait for some more time.
-                await asyncio.sleep(wait_interval)
-            except grpc.RpcError as e:
-                if e.code() == grpc.StatusCode.NOT_FOUND:
-                    logger.debug("Index deleted successfully")
-                    # Index has been created
-                    return
-                else:
-                    logger.error("Failed waiting for index deletion with error: %s", e)
-
-                    raise types.AVSServerError(rpc_error=e)
 
     async def close(self):
         """

--- a/src/aerospike_vector_search/aio/client.py
+++ b/src/aerospike_vector_search/aio/client.py
@@ -805,7 +805,7 @@ class Client(BaseClientMixin, AdminBaseClientMixin):
                 namespace=namespace, name=name, timeout=100_000
             )
         except grpc.RpcError as e:
-            logger.error("Failed waiting for creation with error: %s", e)
+            logger.error("Failed to create index with error: %s", e)
             raise types.AVSServerError(rpc_error=e)
         # Ensure that the created index is synced across all nodes
         await self._indexes_in_sync()
@@ -912,7 +912,7 @@ class Client(BaseClientMixin, AdminBaseClientMixin):
                 namespace=namespace, name=name, timeout=100_000
             )
         except grpc.RpcError as e:
-            logger.error("Failed waiting for deletion with error: %s", e)
+            logger.error("Failed waiting for index deletion with error: %s", e)
             raise types.AVSServerError(rpc_error=e)
         # Ensure that the index is deleted across all nodes
         await self._indexes_in_sync()

--- a/src/aerospike_vector_search/client.py
+++ b/src/aerospike_vector_search/client.py
@@ -1,4 +1,3 @@
-import functools
 import logging
 import sys
 import time

--- a/src/aerospike_vector_search/client.py
+++ b/src/aerospike_vector_search/client.py
@@ -790,6 +790,13 @@ class Client(BaseClientMixin, AdminBaseClientMixin):
         except grpc.RpcError as e:
             logger.error("Failed to create index with error: %s", e)
             raise types.AVSServerError(rpc_error=e)
+        try:
+            self._wait_for_index_creation(
+                namespace=namespace, name=name, timeout=100_000
+            )
+        except grpc.RpcError as e:
+            logger.error("Failed to create index with error: %s", e)
+            raise types.AVSServerError(rpc_error=e)
 
     @_ensure_indexes_in_sync
     def index_update(
@@ -883,6 +890,13 @@ class Client(BaseClientMixin, AdminBaseClientMixin):
             )
         except grpc.RpcError as e:
             logger.error("Failed to drop index with error: %s", e)
+            raise types.AVSServerError(rpc_error=e)
+        try:
+            self._wait_for_index_deletion(
+                namespace=namespace, name=name, timeout=100_000
+            )
+        except grpc.RpcError as e:
+            logger.error("Failed waiting for index deletion with error: %s", e)
             raise types.AVSServerError(rpc_error=e)
 
     def index_list(
@@ -1336,6 +1350,87 @@ class Client(BaseClientMixin, AdminBaseClientMixin):
             logger.error("Failed to list roles with error: %s", e)
             raise types.AVSServerError(rpc_error=e)
         return self._respond_list_roles(response)
+
+    def _wait_for_index_creation(
+        self,
+        *,
+        namespace: str,
+        name: str,
+        timeout: int = sys.maxsize,
+        wait_interval: float = 0.1,
+    ) -> None:
+        """
+        Wait for the index to be created.
+        """
+
+        (index_stub, wait_interval, start_time, _, _, index_creation_request) = (
+            self._prepare_wait_for_index_waiting(namespace, name, wait_interval)
+        )
+        while True:
+
+            try:
+                self._check_timeout(start_time, timeout)
+            except types.AVSClientError as e:
+                logger.error("Failed waiting for index creation with error: %s", e)
+                raise
+            
+            try:
+                index_stub.GetStatus(
+                    index_creation_request,
+                    credentials=self._channel_provider.get_token(),
+                )
+                logger.debug("Index created successfully")
+                # Index has been created
+                return
+            except grpc.RpcError as e:
+                if e.code() == grpc.StatusCode.NOT_FOUND:
+
+                    # Wait for some more time.
+                    time.sleep(wait_interval)
+                else:
+                    logger.error("Failed waiting for index creation with error: %s", e)
+                    raise types.AVSServerError(rpc_error=e)
+
+    def _wait_for_index_deletion(
+        self,
+        *,
+        namespace: str,
+        name: str,
+        timeout: int = sys.maxsize,
+        wait_interval: float = 0.1,
+    ) -> None:
+        """
+        Wait for the index to be deleted.
+        """
+
+        # Wait interval between polling
+        (index_stub, wait_interval, start_time, _, _, index_deletion_request) = (
+            self._prepare_wait_for_index_waiting(namespace, name, wait_interval)
+        )
+
+        while True:
+
+            try:
+                self._check_timeout(start_time, timeout)
+            except types.AVSClientError as e:
+                logger.error("Failed waiting for index deletion with error: %s", e)
+                raise
+
+            try:
+                index_stub.GetStatus(
+                    index_deletion_request,
+                    credentials=self._channel_provider.get_token(),
+                )
+                # Wait for some more time.
+                time.sleep(wait_interval)
+            except grpc.RpcError as e:
+                if e.code() == grpc.StatusCode.NOT_FOUND:
+                    logger.debug("Index deleted successfully")
+                    # Index has been created
+                    return
+                else:
+                    logger.error("Failed waiting for index deletion with error: %s", e)
+                    raise types.AVSServerError(rpc_error=e)
 
     def close(self):
         """

--- a/src/aerospike_vector_search/shared/client_helpers.py
+++ b/src/aerospike_vector_search/shared/client_helpers.py
@@ -352,6 +352,12 @@ class BaseClient(object):
         else:
             raise Exception("Invalid key type" + str(type(key)))
         return key
+
+    def _prepare_wait_for_index_waiting(self, namespace: str, name: str, wait_interval: int) -> (
+        Tuple)[index_pb2_grpc.IndexServiceStub, float, float, bool, int, index_pb2.IndexGetRequest]:
+        return helpers._prepare_wait_for_index_waiting(
+            self, namespace, name, wait_interval
+        )
     
     def _prepare_index_get_percent_unmerged(self, namespace: str, name: str, timeout: Optional[int], logger: Logger) -> (
         Tuple)[index_pb2_grpc.IndexServiceStub, index_pb2.IndexStatusRequest, dict[str, Any]]:
@@ -392,26 +398,7 @@ class BaseClient(object):
 
     def _check_timeout(self, start_time: float, timeout: int):
         if start_time + timeout < time.monotonic():
-            raise AVSClientError(message="timed-out waiting for index creation")
-
-    def _check_completion_condition(
-        self, start_time: float, timeout:int , index_status, unmerged_record_initialized
-    ):
-        self._check_timeout(start_time, timeout)
-
-        if start_time + 10 < time.monotonic():
-            unmerged_record_initialized = True
-
-        if index_status.unmergedRecordCount > 0:
-            unmerged_record_initialized = True
-
-        if (
-            index_status.unmergedRecordCount == 0
-            and unmerged_record_initialized == True
-        ):
-            return True
-        else:
-            return False
+            raise AVSClientError(message="timeout expired")
 
 
 # A dummy method to replace client functionality once the connection is closed.

--- a/src/aerospike_vector_search/shared/client_helpers.py
+++ b/src/aerospike_vector_search/shared/client_helpers.py
@@ -352,12 +352,6 @@ class BaseClient(object):
         else:
             raise Exception("Invalid key type" + str(type(key)))
         return key
-
-    def _prepare_wait_for_index_waiting(self, namespace: str, name: str, wait_interval: int) -> (
-        Tuple)[index_pb2_grpc.IndexServiceStub, float, float, bool, int, index_pb2.IndexGetRequest]:
-        return helpers._prepare_wait_for_index_waiting(
-            self, namespace, name, wait_interval
-        )
     
     def _prepare_index_get_percent_unmerged(self, namespace: str, name: str, timeout: Optional[int], logger: Logger) -> (
         Tuple)[index_pb2_grpc.IndexServiceStub, index_pb2.IndexStatusRequest, dict[str, Any]]:

--- a/tests/standard/test_client_indexes_in_sync.py
+++ b/tests/standard/test_client_indexes_in_sync.py
@@ -10,4 +10,4 @@ from utils import DEFAULT_NAMESPACE, DEFAULT_INDEX_DIMENSION, DEFAULT_VECTOR_FIE
 def test_index(session_vector_client, index):
     client = session_vector_client
     # long timeout just in case test environment is very slow
-    client.indexes_in_sync(timeout=9999)
+    client._indexes_in_sync(timeout=9999)

--- a/tests/unit/test_index_async.py
+++ b/tests/unit/test_index_async.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import MagicMock, AsyncMock
+from unittest.mock import MagicMock
 
 from aerospike_vector_search import types
 from aerospike_vector_search.aio import Index, Client
@@ -255,7 +255,7 @@ async def test_index_get_percent_unmerged_no_params():
 
 
 async def test_index_update():
-    mock_client = AsyncMock(spec=Client)
+    mock_client = MagicMock(spec=Client)
     index = Index(
         client=mock_client,
         name="test_index",
@@ -288,7 +288,7 @@ async def test_index_update():
 
 
 async def test_index_update_no_params():
-    mock_client = AsyncMock(spec=Client)
+    mock_client = MagicMock(spec=Client)
     index = Index(
         client=mock_client,
         name="test_index",
@@ -403,7 +403,7 @@ async def test_index_status_no_params():
 
 
 async def test_index_drop():
-    mock_client = AsyncMock(spec=Client)
+    mock_client = MagicMock(spec=Client)
     index = Index(
         client=mock_client,
         name="test_index",
@@ -426,7 +426,7 @@ async def test_index_drop():
 
 
 async def test_index_drop_no_params():
-    mock_client = AsyncMock(spec=Client)
+    mock_client = MagicMock(spec=Client)
     index = Index(
         client=mock_client,
         name="test_index",

--- a/tests/unit/test_index_async.py
+++ b/tests/unit/test_index_async.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, AsyncMock
 
 from aerospike_vector_search import types
 from aerospike_vector_search.aio import Index, Client
@@ -255,7 +255,7 @@ async def test_index_get_percent_unmerged_no_params():
 
 
 async def test_index_update():
-    mock_client = MagicMock(spec=Client)
+    mock_client = AsyncMock(spec=Client)
     index = Index(
         client=mock_client,
         name="test_index",
@@ -288,7 +288,7 @@ async def test_index_update():
 
 
 async def test_index_update_no_params():
-    mock_client = MagicMock(spec=Client)
+    mock_client = AsyncMock(spec=Client)
     index = Index(
         client=mock_client,
         name="test_index",
@@ -403,7 +403,7 @@ async def test_index_status_no_params():
 
 
 async def test_index_drop():
-    mock_client = MagicMock(spec=Client)
+    mock_client = AsyncMock(spec=Client)
     index = Index(
         client=mock_client,
         name="test_index",
@@ -426,7 +426,7 @@ async def test_index_drop():
 
 
 async def test_index_drop_no_params():
-    mock_client = MagicMock(spec=Client)
+    mock_client = AsyncMock(spec=Client)
     index = Index(
         client=mock_client,
         name="test_index",


### PR DESCRIPTION
This hides the indexes_in_sync method and instead calls it from methods that modify indexes so that they return after index changes have propagated through the cluster.