### PR TITLE
fix: skip index syncing if AVS server does not support it vec-561

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,7 @@ jobs:
 
     - name: Run integration tests
       run: |
-        docker run -d  --network=host -p 5000:5000 --name aerospike-vector-search -v ./aerospike-vector-search.yml:/etc/aerospike-vector-search/aerospike-vector-search.yml -v ./features.conf:/etc/aerospike-vector-search/features.conf aerospike.jfrog.io/docker/aerospike/aerospike-vector-search-private:1.0.1-SNAPSHOT
+        docker run -d  --network=host -p 5000:5000 --name aerospike-vector-search -v ./aerospike-vector-search.yml:/etc/aerospike-vector-search/aerospike-vector-search.yml -v ./features.conf:/etc/aerospike-vector-search/features.conf aerospike/aerospike-vector-search:1.1.0
     
         docker run -d --name aerospike -p 3000:3000 -v .:/etc/aerospike aerospike/aerospike-server-enterprise:latest 
 
@@ -181,7 +181,7 @@ jobs:
     - name: Run unit tests
       run: |
 
-        docker run -d --name aerospike-vector-search --network=host -p 5000:5000   -v $(pwd):/etc/aerospike-vector-search aerospike.jfrog.io/docker/aerospike/aerospike-vector-search-private:1.0.1-SNAPSHOT
+        docker run -d --name aerospike-vector-search --network=host -p 5000:5000   -v $(pwd):/etc/aerospike-vector-search aerospike/aerospike-vector-search:1.1.0
         docker run -d --name aerospike -p 3000:3000 -v .:/etc/aerospike aerospike/aerospike-server-enterprise:latest 
 
         sleep 5
@@ -262,7 +262,7 @@ jobs:
     - name: Run unit tests
       run: |
 
-        docker run -d --name aerospike-vector-search --network=host -p 5000:5000   -v $(pwd):/etc/aerospike-vector-search aerospike.jfrog.io/docker/aerospike/aerospike-vector-search-private:1.0.1-SNAPSHOT
+        docker run -d --name aerospike-vector-search --network=host -p 5000:5000   -v $(pwd):/etc/aerospike-vector-search aerospike/aerospike-vector-search:1.1.0
         docker run -d --name aerospike -p 3000:3000 -v .:/etc/aerospike aerospike/aerospike-server-enterprise:latest 
 
         sleep 5
@@ -342,7 +342,7 @@ jobs:
     - name: Run unit tests
       run: |
 
-        docker run -d --name aerospike-vector-search --network=host -p 5000:5000   -v $(pwd):/etc/aerospike-vector-search aerospike.jfrog.io/docker/aerospike/aerospike-vector-search-private:1.0.1-SNAPSHOT
+        docker run -d --name aerospike-vector-search --network=host -p 5000:5000   -v $(pwd):/etc/aerospike-vector-search aerospike/aerospike-vector-search:1.1.0
         docker run -d --name aerospike -p 3000:3000 -v .:/etc/aerospike aerospike/aerospike-server-enterprise:latest 
 
         sleep 5
@@ -425,7 +425,7 @@ jobs:
     - name: Run unit tests
       run: |
 
-        docker run -d --name aerospike-vector-search --network=host -p 5000:5000  -v $(pwd):/etc/aerospike-vector-search aerospike.jfrog.io/docker/aerospike/aerospike-vector-search-private:1.0.1-SNAPSHOT
+        docker run -d --name aerospike-vector-search --network=host -p 5000:5000  -v $(pwd):/etc/aerospike-vector-search aerospike/aerospike-vector-search:1.1.0
         docker run -d --name aerospike -p 3000:3000 -v .:/etc/aerospike aerospike/aerospike-server-enterprise:latest 
 
         sleep 5
@@ -502,7 +502,7 @@ jobs:
     - name: Run unit tests
       run: |
 
-        docker run -d --name aerospike-vector-search --network=host -p 5000:5000  -v $(pwd):/etc/aerospike-vector-search aerospike.jfrog.io/docker/aerospike/aerospike-vector-search-private:1.0.1-SNAPSHOT
+        docker run -d --name aerospike-vector-search --network=host -p 5000:5000  -v $(pwd):/etc/aerospike-vector-search aerospike/aerospike-vector-search:1.1.0
         docker run -d --name aerospike -p 3000:3000 -v .:/etc/aerospike aerospike/aerospike-server-enterprise:latest 
 
         sleep 5
@@ -580,7 +580,7 @@ jobs:
     - name: Run unit tests
       run: |
 
-        docker run -d --name aerospike-vector-search --network=host -p 5000:5000  -v $(pwd):/etc/aerospike-vector-search aerospike.jfrog.io/docker/aerospike/aerospike-vector-search-private:1.0.1-SNAPSHOT
+        docker run -d --name aerospike-vector-search --network=host -p 5000:5000  -v $(pwd):/etc/aerospike-vector-search aerospike/aerospike-vector-search:1.1.0
         docker run -d --name aerospike -p 3000:3000 -v .:/etc/aerospike aerospike/aerospike-server-enterprise:latest 
 
         sleep 5
@@ -653,7 +653,7 @@ jobs:
     - name: Run unit tests
       run: |
 
-        docker run -d --name aerospike-vector-search --network=host -p 5000:5000  -v $(pwd):/etc/aerospike-vector-search aerospike.jfrog.io/docker/aerospike/aerospike-vector-search-private:1.0.1-SNAPSHOT
+        docker run -d --name aerospike-vector-search --network=host -p 5000:5000  -v $(pwd):/etc/aerospike-vector-search aerospike/aerospike-vector-search:1.1.0
         docker run -d --name aerospike -p 3000:3000 -v .:/etc/aerospike aerospike/aerospike-server-enterprise:latest 
 
         sleep 5
@@ -702,7 +702,7 @@ jobs:
     - name: Build and install aerospike-vector-search
       run: |
         python -m build
-        pip install dist/aerospike_vector_search-4.1.0-py3-none-any.whl
+        pip install dist/aerospike_vector_search-4.1.1-py3-none-any.whl
 
     - name: Upload to Codecov
       uses: codecov/codecov-action@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ classifiers = [
 version = "4.1.1"
 requires-python = ">3.8"
 dependencies = [
-    "grpcio == 1.70.0",
-    "protobuf == 5.29.0",
+    "grpcio == 1.71.0",
+    "protobuf == 5.29.3",
     "pyjwt == 2.9.0",
     "numpy",
     "sphinx_rtd_theme"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Database"
 ]
-version = "4.1.0"
+version = "4.1.1"
 requires-python = ">3.8"
 dependencies = [
     "grpcio == 1.70.0",

--- a/src/aerospike_vector_search/aio/client.py
+++ b/src/aerospike_vector_search/aio/client.py
@@ -1116,6 +1116,12 @@ class Client(BaseClientMixin, AdminBaseClientMixin):
                 **kwargs,
             )
         except grpc.RpcError as e:
+            # If the server does not support index syncing it means the server is older than 1.1.0
+            # This is a non-critical error and can be ignored
+            if e.code() == grpc.StatusCode.UNIMPLEMENTED:
+                logger.warn("Index sync is not supported in this version of the server, skipping sync")
+                return
+
             logger.error("Failed waiting for indices to sync with error: %s", e)
             raise types.AVSServerError(rpc_error=e)
 

--- a/src/aerospike_vector_search/client.py
+++ b/src/aerospike_vector_search/client.py
@@ -1074,6 +1074,12 @@ class Client(BaseClientMixin, AdminBaseClientMixin):
                 **kwargs,
             )
         except grpc.RpcError as e:
+            # If the server does not support index syncing it means the server is older than 1.1.0
+            # This is a non-critical error and can be ignored
+            if e.code() == grpc.StatusCode.UNIMPLEMENTED:
+                logger.warn("Index sync is not supported in this version of the server, skipping sync")
+                return
+
             logger.error("Failed waiting for indices to sync with error: %s", e)
             raise types.AVSServerError(rpc_error=e)
 

--- a/src/aerospike_vector_search/shared/proto_generated/auth_pb2_grpc.py
+++ b/src/aerospike_vector_search/shared/proto_generated/auth_pb2_grpc.py
@@ -5,7 +5,7 @@ import warnings
 
 from . import auth_pb2 as auth__pb2
 
-GRPC_GENERATED_VERSION = '1.70.0'
+GRPC_GENERATED_VERSION = '1.71.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/src/aerospike_vector_search/shared/proto_generated/index_pb2_grpc.py
+++ b/src/aerospike_vector_search/shared/proto_generated/index_pb2_grpc.py
@@ -7,7 +7,7 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 from . import index_pb2 as index__pb2
 from . import types_pb2 as types__pb2
 
-GRPC_GENERATED_VERSION = '1.70.0'
+GRPC_GENERATED_VERSION = '1.71.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/src/aerospike_vector_search/shared/proto_generated/transact_pb2_grpc.py
+++ b/src/aerospike_vector_search/shared/proto_generated/transact_pb2_grpc.py
@@ -7,7 +7,7 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 from . import transact_pb2 as transact__pb2
 from . import types_pb2 as types__pb2
 
-GRPC_GENERATED_VERSION = '1.70.0'
+GRPC_GENERATED_VERSION = '1.71.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/src/aerospike_vector_search/shared/proto_generated/types_pb2_grpc.py
+++ b/src/aerospike_vector_search/shared/proto_generated/types_pb2_grpc.py
@@ -4,7 +4,7 @@ import grpc
 import warnings
 
 
-GRPC_GENERATED_VERSION = '1.70.0'
+GRPC_GENERATED_VERSION = '1.71.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/src/aerospike_vector_search/shared/proto_generated/user_admin_pb2_grpc.py
+++ b/src/aerospike_vector_search/shared/proto_generated/user_admin_pb2_grpc.py
@@ -7,7 +7,7 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 from . import types_pb2 as types__pb2
 from . import user_admin_pb2 as user__admin__pb2
 
-GRPC_GENERATED_VERSION = '1.70.0'
+GRPC_GENERATED_VERSION = '1.71.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/src/aerospike_vector_search/shared/proto_generated/vector_db_pb2_grpc.py
+++ b/src/aerospike_vector_search/shared/proto_generated/vector_db_pb2_grpc.py
@@ -6,7 +6,7 @@ import warnings
 from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 from . import vector_db_pb2 as vector__db__pb2
 
-GRPC_GENERATED_VERSION = '1.70.0'
+GRPC_GENERATED_VERSION = '1.71.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 


### PR DESCRIPTION
This fixes backwards compatibility with AVS servers older than 1.1.0.